### PR TITLE
Hash Vite entry script for Cloudflare

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/assets/index.js"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,9 @@ export default defineConfig(({ mode }) => ({
     rollupOptions: {
       output: {
         manualChunks: undefined,
-        entryFileNames: `assets/index.js`,
+        entryFileNames: `assets/[name]-[hash].js`,
         chunkFileNames: `assets/[name]-[hash].js`,
-        assetFileNames: `assets/[name]-[hash].[ext]`
+        assetFileNames: `assets/[name]-[hash].[ext]`,
       },
     },
   },


### PR DESCRIPTION
## Summary
- hash Vite entry output so Cloudflare serves JavaScript bundle with correct MIME type

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 12 errors, 13 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b84cde1cbc8329ad37030e6b15e312